### PR TITLE
add condition none

### DIFF
--- a/lib/kubes_google/service_account.rb
+++ b/lib/kubes_google/service_account.rb
@@ -40,6 +40,7 @@ module KubesGoogle
       sh "gcloud iam service-accounts add-iam-policy-binding \
                 --role roles/iam.workloadIdentityUser \
                 --member #{member} \
+                --condition=None \
                 #{@service_account}".squish
     end
 


### PR DESCRIPTION
Looks like some `gcloud` versions require `--condition=None` when running in non-interactive mode.